### PR TITLE
defender input bug fix - resulted in NAN when deleting input

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -40,14 +40,13 @@ const Form = (props: FormProps) => {
 
 	function handleChange(evt: Readonly<React.ChangeEvent<HTMLInputElement>>) {
 		const { value } = evt.target;
-		const newValue = parseFloat(value.toString());
 
 		setFormValues({
 			...formValues,
 			[evt.target.name]:
 				evt.target.name === "defenderCount"
-					? String(newValue)
-					: Number(newValue),
+					? String(value)
+					: parseFloat(value.toString()),
 		});
 	}
 


### PR DESCRIPTION
OVERVIEW:
+Small Bug fix:  Defender input showed NAN when user deleted the default input